### PR TITLE
add arp_types.vhd to lib

### DIFF
--- a/run.py
+++ b/run.py
@@ -9,6 +9,7 @@ udp_ip_lib = prj.add_library('udp_ip_lib')
 #udp_ip_lib.add_source_files(join(root, 'bench', 'vhdl', '*.vhd'))
 udp_ip_lib.add_source_files(join(root, 'rtl', 'vhdl', 'UDP_TX.vhd'))
 udp_ip_lib.add_source_files(join(root, 'rtl', 'vhdl', 'ipv4_types.vhd'))
+udp_ip_lib.add_source_files(join(root, 'rtl', 'vhdl', 'arp_types.vhd'))
 udp_ip_lib.add_source_files(join(root, 'rtl', 'vhdl', 'axi.vhd'))
 udp_ip_lib.add_source_files(join(root, 'bench', 'vhdl', 'UDP_TX_tb.vhd'))
 


### PR DESCRIPTION
Resolves the following error on a fresh clone:

```
python run.py --export-json=project.json
WARNING - udp_ip_stack\rtl\vhdl\ipv4_types.vhd: failed to find a primary design unit 'arp_types' in library 'udp_ip_lib'
```